### PR TITLE
URL-encode ISO 8601 date parameters in HttpJsonApi

### DIFF
--- a/src/Exercise/HttpJsonApi.php
+++ b/src/Exercise/HttpJsonApi.php
@@ -40,9 +40,9 @@ class HttpJsonApi extends AbstractExercise implements ExerciseInterface, CgiExer
     {
         $url = 'http://www.time.com/api/%s?iso=%s';
         return [
-            (new Request(sprintf($url, 'parsetime', (new \DateTime)->format(DATE_ISO8601))))
+            (new Request(sprintf($url, 'parsetime', urlencode((new \DateTime)->format(DATE_ISO8601)))))
                 ->withMethod('GET'),
-            (new Request(sprintf($url, 'unixtime', (new \DateTime)->format(DATE_ISO8601))))
+            (new Request(sprintf($url, 'unixtime', urlencode((new \DateTime)->format(DATE_ISO8601)))))
                 ->withMethod('GET'),
         ];
     }


### PR DESCRIPTION
ISO 8601 dates can include the + character (for timezones east of Greenwich) which will be interpreted as a space, breaking the suggested solution ($_GET['iso'] is not a correctly formatted for parsing by DateTime).
