### PR TITLE
Fix unixtime response in http-json-api solution

### DIFF
--- a/exercises/http-json-api/problem/problem.md
+++ b/exercises/http-json-api/problem/problem.md
@@ -41,7 +41,7 @@ You should also be a good web citizen and set the Content-Type properly:
 header('Content-Type: application/json');
 ```
 
-The PHP `DateTime` object can print dates in ISO format, e.g. `(new \DateTime())->format('u');`. It can also parse this format if you pass the string into the `\DateTime` constructor. The various parameters to `format()` will also
+The PHP `DateTime` object can print dates as a UNIX timestamp, e.g. `(new \DateTime())->format('U');`. It can also parse this format if you pass the string into the `\DateTime` constructor. The various parameters to `format()` will also
 come in handy. You can find the documentation here:
     [http://php.net/manual/en/class.datetime.php]()
 

--- a/exercises/http-json-api/solution/solution.php
+++ b/exercises/http-json-api/solution/solution.php
@@ -20,7 +20,7 @@ if ($urlParts['path'] === '/api/parsetime') {
 if ($urlParts['path'] === '/api/unixtime') {
     if (isset($_GET['iso'])) {
         $date = new \DateTime($_GET['iso']);
-        echo json_encode(["unixtime" => $date->format('u')]);
+        echo json_encode(["unixtime" => $date->format('U')]);
         exit;
     }
 }


### PR DESCRIPTION
The solution always returns {"unixtime": "000000"} because of incorrect DateTime format.

Replace 'u' for microseconds with 'U' for unix time.
