### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+#
+# PHP School - Learn You PHP
+# A revolutionary new way to learn PHP.
+# Bring your imagination to life in an open learning eco-system.
+# http://phpschool.io
+#
+
+FROM phpschool/workshop-manager
+MAINTAINER Michael Woodward <mikeymike.mw@gmail.com>
+
+RUN workshop-manager install learnyouphp
+
+RUN echo "\
+----------------------------------\n\
+Welcome to Learn You PHP! \n\
+To get started run the command: learnyouphp \n\
+----------------------------------" > /etc/motd
+RUN echo "cat /etc/motd" >> ~/.bashrc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+    workshop:
+        container_name: phpschool-learnyouphp
+        image: phpschool/learn-you-php
+        volumes:
+            - $PHPSCHOOL_CODE_DIR/learnyouphp:/phpschool:rw
+        stdin_open: true
+        tty: true


### PR DESCRIPTION
Okay so this is my initial thought process on providing docker as the main method of running workshops. 

1. Each workshop will have to have a docker image and a compose file. 
2. Require new ENV var on host, `PHPSCHOOL_CODE_DIR`
  - This is key to allow us to mount the files into the container and run from 3rd party 😉 
3. We just run `docker-compose up -d` which will spin up all required containers for workshop
  - Note if `$PHPSCHOOL_CODE_DIR/learnyouphp` doesn't exist it should be created by docker for us 👌 
4. Profit from cross platform, highly customisable environments 🙌 

It's an incredibly simple approach that I think will work a treat for us