### PR TITLE
Persist user state in Docker environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
         container_name: phpschool-learnyouphp
         image: phpschool/learn-you-php
         volumes:
+            - ~/.phpschool-save.json:/root/.phpschool-save.json
             - $PHPSCHOOL_CODE_DIR/learnyouphp:/phpschool:rw
         stdin_open: true
         tty: true


### PR DESCRIPTION
Added a docker volume to persist the user's home directory inside the container. I've had to do the whole home dir because compose cannot volume single files, at least not cross platform iirc. 

However there shouldn't be any issues with this because we mount solutions etc into `/phpschool` which is outside of the home dir so wouldn't cause any conflicts 👍  